### PR TITLE
Two native Windows fixes for GPR#1010

### DIFF
--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -103,6 +103,7 @@ LIBUNWIND_LINK_FLAGS=
 PROFINFO_WIDTH=26
 SAFE_STRING=false
 AFL_INSTRUMENT=false
+AWK=gawk
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -103,6 +103,7 @@ LIBUNWIND_LINK_FLAGS=
 PROFINFO_WIDTH=26
 SAFE_STRING=false
 AFL_INSTRUMENT=false
+AWK=gawk
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -96,6 +96,7 @@ LIBUNWIND_LINK_FLAGS=
 PROFINFO_WIDTH=26
 SAFE_STRING=false
 AFL_INSTRUMENT=false
+AWK=gawk
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -95,6 +95,7 @@ LIBUNWIND_LINK_FLAGS=
 PROFINFO_WIDTH=26
 SAFE_STRING=false
 AFL_INSTRUMENT=false
+AWK=gawk
 
 ########## Configuration for the bytecode compiler
 

--- a/configure
+++ b/configure
@@ -2043,6 +2043,7 @@ echo "FLAMBDA=$flambda" >> Makefile
 echo "SAFE_STRING=$safe_string" >> Makefile
 echo "AFL_INSTRUMENT=$afl_instrument" >> Makefile
 echo "MAX_TESTSUITE_DIR_RETRIES=$max_testsuite_dir_retries" >> Makefile
+echo "AWK=awk" >> Makefile
 
 
 rm -f tst hasgot.c

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -447,7 +447,7 @@ stdlib_non_prefixed/%.mli: ../otherlibs/num/%.mli
 	cp $< $@
 
 stdlib_non_prefixed/pervasives.mli: ../stdlib/stdlib.mli stdlib_non_prefixed/extract_pervasives.awk
-	awk -f stdlib_non_prefixed/extract_pervasives.awk $< > $@
+	$(AWK) -f stdlib_non_prefixed/extract_pervasives.awk $< > $@
 
 stdlib_non_prefixed/pervasives.cmi: stdlib_non_prefixed/pervasives.mli
 	$(OCAMLC_SNP) -c $<

--- a/ocamldoc/stdlib_non_prefixed/extract_pervasives.awk
+++ b/ocamldoc/stdlib_non_prefixed/extract_pervasives.awk
@@ -1,8 +1,8 @@
 # This script extract the Pervasives submodule from stdlib.mli into
 # pervasives.mli, for ocamldoc
 BEGIN { state=0 }
-$0 == "module Pervasives : sig" && state == 0 { state=1 }
-$0 == "end"                     && state == 2 { state=3 }
+/^module Pervasives : sig\r?$/ && state == 0 { state=1 }
+/^end\r?$/                     && state == 2 { state=3 }
 {
     if (state == 1) state=2;
     else if (state == 2) print

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -17,7 +17,7 @@
 case $1 in
   stdlib.cm[iox]|stdlib.p.cmx)
       echo ' -nopervasives -no-alias-deps -w -49' \
-           ' -pp "awk -f expand_module_aliases.awk"';;
+           ' -pp "$AWK -f expand_module_aliases.awk"';;
   stdlib__pervasives.cm[iox]|stdlib__pervasives.p.cmx) echo ' -nopervasives';;
   camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0';;
   stdlib__buffer.cmx|stdlib__buffer.p.cmx) echo ' -inline 3';;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -219,6 +219,8 @@ clean::
 
 .SUFFIXES: .mli .ml .cmi .cmo .cmx .p.cmx
 
+export AWK
+
 %.cmi: %.mli
 	$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) -c $<
 
@@ -278,11 +280,11 @@ SPACE := $(EMPTY) $(EMPTY)
 depend:
 	$(CAMLDEP) -slash $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
 	  > .depend.tmp
-	$(CAMLDEP) -slash -pp "awk -f remove_module_aliases.awk" \
+	$(CAMLDEP) -slash -pp "$(AWK) -f remove_module_aliases.awk" \
 	  stdlib.ml stdlib.mli >> .depend.tmp
 	$(CAMLDEP) -slash $(filter-out stdlib.%,$(wildcard *.ml)) \
 	  | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend.tmp
-	$(CAMLDEP) -slash -pp "awk -f remove_module_aliases.awk" stdlib.ml \
+	$(CAMLDEP) -slash -pp "$(AWK) -f remove_module_aliases.awk" stdlib.ml \
 	  | sed -e 's/\.cmx : /.p.cmx : /g' >> .depend.tmp
 	sed -re \
 	  's#(^| )(${subst ${SPACE},|,${PREFIXED_OBJS:stdlib__%.cmo=%}})[.]#\1stdlib__\2.#g' \

--- a/stdlib/expand_module_aliases.awk
+++ b/stdlib/expand_module_aliases.awk
@@ -2,7 +2,7 @@
 # stdlib.ml and stdlib.mli
 BEGIN { state=0 }
 NR == 1 { printf ("# 1 \"%s\"\n", FILENAME) }
-$0 == "(*MODULE_ALIASES*)" { state=1 }
+/\(\*MODULE_ALIASES\*\)\r?/ { state=1 }
 { if (state==0)
     print;
   else if (state==1)

--- a/stdlib/remove_module_aliases.awk
+++ b/stdlib/remove_module_aliases.awk
@@ -3,5 +3,5 @@
 # other modules
 BEGIN { in_aliases=0 }
 NR == 1 { printf ("# 1 \"%s\"\n", FILENAME) }
-$0 == "(*MODULE_ALIASES*)" { in_aliases=1 }
+/^\(\*MODULE_ALIASES\*\)\r?$/ { in_aliases=1 }
 !in_aliases { print }


### PR DESCRIPTION
While reviewing 1010 again, I had issues with building with new Cygwin tools on a CRLF git checkout (AppVeyor does an LF checkout, so it doesn't pick these things up - at some point, I may alter the checkout of one of the builds so that we catch these things earlier)