### PR TITLE
Update manual build process for the prefixed stdlib

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -14,21 +14,37 @@ SRC = $(abspath ../../)
 export LD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
 export DYLD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
 
-OCAMLDOC=$(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc -hide Pervasives
-MLIS=$(SRC)/stdlib/*.mli \
-	$(SRC)/utils/*.mli \
-	$(SRC)/parsing/*.mli \
-	$(SRC)/otherlibs/bigarray/bigarray.mli \
-	$(SRC)/otherlibs/dynlink/dynlink.mli \
-	$(SRC)/otherlibs/graph/graphics.mli \
-	$(SRC)/otherlibs/graph/graphicsX11.mli \
-	$(SRC)/otherlibs/num/num.mli \
-	$(SRC)/otherlibs/num/arith_status.mli \
-	$(SRC)/otherlibs/num/big_int.mli \
-	$(SRC)/otherlibs/num/ratio.mli \
-	$(SRC)/otherlibs/str/*.mli \
-	$(SRC)/otherlibs/systhreads/*.mli \
-	$(SRC)/otherlibs/unix/*.mli
+P :=
+include $(SRC)/stdlib/StdlibModules
+MLIDIR=$(SRC)/ocamldoc/stdlib_non_prefixed/
+
+STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
+PARSING_MLIS := $(wildcard $(SRC)/parsing/*.mli)
+
+OCAMLDOC=$(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc -hide Pervasives \
+-nostdlib  -initially-opened-module Pervasives
+
+MLIS=$(STDLIB_MODULES:%=%.mli) \
+  $(PARSING_MLIS:$(SRC)/parsing/%.mli=%.mli) \
+  unix.mli \
+  unixLabels.mli \
+  str.mli \
+  bigarray.mli \
+  num.mli \
+  arith_status.mli \
+  nat.mli \
+  big_int.mli \
+  ratio.mli \
+  graphics.mli \
+  graphicsX11.mli \
+  dynlink.mli \
+  thread.mli \
+  mutex.mli \
+  condition.mli \
+  event.mli \
+  threadUnix.mli
+
+MLIS:= $(addprefix $(MLIDIR), $(MLIS))
 
 manual: files
 	cd texstuff; \
@@ -60,16 +76,7 @@ html: files
 	mkdir -p libref ; \
 	$(OCAMLDOC) -colorize-code -sort -html \
 	-d libref \
-	-I $(SRC)/stdlib  \
-	-I $(SRC)/utils  \
-	-I $(SRC)/parsing \
-	-I $(SRC)/otherlibs/bigarray \
-	-I $(SRC)/otherlibs/dynlink \
-	-I $(SRC)/otherlibs/graph \
-	-I $(SRC)/otherlibs/num \
-	-I $(SRC)/otherlibs/str \
-	-I $(SRC)/otherlibs/systhreads \
-	-I $(SRC)/otherlibs/unix \
+	-I $(MLIDIR) \
 	$(MLIS) ; \
 	cp -f ../style.css libref ; \
 	${HEVEA} ${HTML} -I .. -I ../refman -I ../library -I ../cmds \

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -14,37 +14,8 @@ SRC = $(abspath ../../)
 export LD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
 export DYLD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
 
-P :=
-include $(SRC)/stdlib/StdlibModules
-MLIDIR=$(SRC)/ocamldoc/stdlib_non_prefixed/
-
-STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
-PARSING_MLIS := $(wildcard $(SRC)/parsing/*.mli)
-
 OCAMLDOC=$(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc -hide Pervasives \
 -nostdlib  -initially-opened-module Pervasives
-
-MLIS=$(STDLIB_MODULES:%=%.mli) \
-  $(PARSING_MLIS:$(SRC)/parsing/%.mli=%.mli) \
-  unix.mli \
-  unixLabels.mli \
-  str.mli \
-  bigarray.mli \
-  num.mli \
-  arith_status.mli \
-  nat.mli \
-  big_int.mli \
-  ratio.mli \
-  graphics.mli \
-  graphicsX11.mli \
-  dynlink.mli \
-  thread.mli \
-  mutex.mli \
-  condition.mli \
-  event.mli \
-  threadUnix.mli
-
-MLIS:= $(addprefix $(MLIDIR), $(MLIS))
 
 manual: files
 	cd texstuff; \
@@ -71,13 +42,17 @@ index::
 	  makeindex pdfmanual.idx
 	cd texstuff; makeindex pdfmanual.kwd.idx
 
-html: files
+
+# Copy and unprefix the standard library when needed
+include $(SRC)/ocamldoc/Makefile.unprefix
+
+html: files $(STDLIB_CMIS)
 	cd htmlman; \
 	mkdir -p libref ; \
 	$(OCAMLDOC) -colorize-code -sort -html \
 	-d libref \
-	-I $(MLIDIR) \
-	$(MLIS) ; \
+	-I $(STDLIB_UNPREFIXED) \
+	$(STDLIB_MLIS) ; \
 	cp -f ../style.css libref ; \
 	${HEVEA} ${HTML} -I .. -I ../refman -I ../library -I ../cmds \
 	         -I ../tutorials -I ../../styles -I ../texstuff manual.hva \
@@ -142,6 +117,7 @@ release:
 
 .SUFFIXES:
 .SUFFIXES: .tex .etex .htex
+
 
 .etex.tex:
 	../tools/texquote2 < $*.etex > $*.tex

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -1,6 +1,14 @@
 CORE_INTF=Pervasives.tex
 
-STDLIB_INTF=Arg.tex Array.tex ArrayLabels.tex Char.tex Complex.tex \
+CSLDIR=$(RELEASEDIR)
+P :=
+include $(CSLDIR)/stdlib/StdlibModules
+MLIDIR=$(CSLDIR)/ocamldoc/stdlib_non_prefixed/
+
+STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
+PARSING_MLIS := $(wildcard $(CSLDIR)/parsing/*.mli)
+
+STDLIB_INTF= Arg.tex Array.tex ArrayLabels.tex Char.tex Complex.tex \
   Digest.tex Filename.tex Format.tex \
   Gc.tex Genlex.tex Hashtbl.tex Int32.tex Int64.tex \
   Lazy.tex Lexing.tex List.tex ListLabels.tex Map.tex Marshal.tex \
@@ -19,22 +27,30 @@ OTHERLIB_INTF=Unix.tex UnixLabels.tex Str.tex \
   Thread.tex Mutex.tex Condition.tex Event.tex ThreadUnix.tex \
   Dynlink.tex Bigarray.tex
 
-
 INTF=$(CORE_INTF) $(STDLIB_INTF) $(COMPILER_LIBS_INTF) $(OTHERLIB_INTF)
 
-MLIS=$(CSLDIR)/stdlib/*.mli \
-	$(CSLDIR)/utils/*.mli \
-	$(CSLDIR)/parsing/*.mli \
-	$(CSLDIR)/otherlibs/bigarray/bigarray.mli \
-	$(CSLDIR)/otherlibs/dynlink/dynlink.mli \
-	$(CSLDIR)/otherlibs/graph/graphics.mli \
-	$(CSLDIR)/otherlibs/graph/graphicsX11.mli \
-	$(CSLDIR)/otherlibs/num/num.mli \
-	$(CSLDIR)/otherlibs/num/arith_status.mli \
-	$(CSLDIR)/otherlibs/num/big_int.mli \
-	$(CSLDIR)/otherlibs/str/*.mli \
-	$(CSLDIR)/otherlibs/systhreads/*.mli \
-	$(CSLDIR)/otherlibs/unix/*.mli
+
+MLIS= $(STDLIB_MODULES:%=%.mli) \
+  $(PARSING_MLIS:$(CSLDIR)/parsing/%.mli=%.mli) \
+  unix.mli \
+  unixLabels.mli \
+  str.mli \
+  bigarray.mli \
+  num.mli \
+  arith_status.mli \
+  nat.mli \
+  big_int.mli \
+  ratio.mli \
+  graphics.mli \
+  graphicsX11.mli \
+  dynlink.mli \
+  thread.mli \
+  mutex.mli \
+  condition.mli \
+  event.mli \
+  threadUnix.mli
+
+MLIS:=$(addprefix $(MLIDIR), $(MLIS))
 
 BLURB=core.tex builtin.tex stdlib.tex compilerlibs.tex \
   libunix.tex libstr.tex libnum.tex libgraph.tex \
@@ -45,9 +61,9 @@ FILES=$(BLURB) $(INTF)
 FORMAT=../../tools/format-intf
 TEXQUOTE=../../tools/texquote2
 
-CSLDIR=$(RELEASEDIR)
 
-VPATH=.:$(CSLDIR)/stdlib:$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
+
+VPATH=.:$(STDLIB_DIR):$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
 
 etex-files: $(BLURB)
 all: libs
@@ -55,18 +71,12 @@ all: libs
 
 libs: $(FILES)
 
+OCAMLDOC = $(CSLDIR)/byterun/ocamlrun $(CSLDIR)/ocamldoc/ocamldoc -latex \
+-nostdlib -initially-opened-module Pervasives
+
 $(INTF): $(MLIS)
-	$(CSLDIR)/byterun/ocamlrun $(CSLDIR)/ocamldoc/ocamldoc -latex \
-	-I $(CSLDIR)/utils \
-	-I $(CSLDIR)/stdlib \
-	-I $(CSLDIR)/parsing \
-	-I $(CSLDIR)/otherlibs/bigarray \
-	-I $(CSLDIR)/otherlibs/dynlink \
-	-I $(CSLDIR)/otherlibs/graph \
-	-I $(CSLDIR)/otherlibs/num \
-	-I $(CSLDIR)/otherlibs/str \
-	-I $(CSLDIR)/otherlibs/systhreads \
-	-I $(CSLDIR)/otherlibs/unix \
+	 $(OCAMLDOC) \
+	-I $(MLIDIR) \
 	$(MLIS) \
 	-sepfiles \
 	-latextitle "6,subsection*" \

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -1,12 +1,6 @@
 CORE_INTF=Pervasives.tex
 
 CSLDIR=$(RELEASEDIR)
-P :=
-include $(CSLDIR)/stdlib/StdlibModules
-MLIDIR=$(CSLDIR)/ocamldoc/stdlib_non_prefixed/
-
-STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
-PARSING_MLIS := $(wildcard $(CSLDIR)/parsing/*.mli)
 
 STDLIB_INTF= Arg.tex Array.tex ArrayLabels.tex Char.tex Complex.tex \
   Digest.tex Filename.tex Format.tex \
@@ -29,29 +23,6 @@ OTHERLIB_INTF=Unix.tex UnixLabels.tex Str.tex \
 
 INTF=$(CORE_INTF) $(STDLIB_INTF) $(COMPILER_LIBS_INTF) $(OTHERLIB_INTF)
 
-
-MLIS= $(STDLIB_MODULES:%=%.mli) \
-  $(PARSING_MLIS:$(CSLDIR)/parsing/%.mli=%.mli) \
-  unix.mli \
-  unixLabels.mli \
-  str.mli \
-  bigarray.mli \
-  num.mli \
-  arith_status.mli \
-  nat.mli \
-  big_int.mli \
-  ratio.mli \
-  graphics.mli \
-  graphicsX11.mli \
-  dynlink.mli \
-  thread.mli \
-  mutex.mli \
-  condition.mli \
-  event.mli \
-  threadUnix.mli
-
-MLIS:=$(addprefix $(MLIDIR), $(MLIS))
-
 BLURB=core.tex builtin.tex stdlib.tex compilerlibs.tex \
   libunix.tex libstr.tex libnum.tex libgraph.tex \
   libthreads.tex libdynlink.tex libbigarray.tex
@@ -60,8 +31,6 @@ FILES=$(BLURB) $(INTF)
 
 FORMAT=../../tools/format-intf
 TEXQUOTE=../../tools/texquote2
-
-
 
 VPATH=.:$(STDLIB_DIR):$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
 
@@ -74,10 +43,14 @@ libs: $(FILES)
 OCAMLDOC = $(CSLDIR)/byterun/ocamlrun $(CSLDIR)/ocamldoc/ocamldoc -latex \
 -nostdlib -initially-opened-module Pervasives
 
-$(INTF): $(MLIS)
+# Copy and unprefix the standard library when needed
+SRC=../../..
+include $(SRC)/ocamldoc/Makefile.unprefix
+
+$(INTF):  $(STDLIB_CMIS)
 	 $(OCAMLDOC) \
-	-I $(MLIDIR) \
-	$(MLIS) \
+	-I $(STDLIB_UNPREFIXED) \
+	$(STDLIB_MLIS) \
 	-sepfiles \
 	-latextitle "6,subsection*" \
 	-latextitle "7,subsubsection*" \
@@ -103,7 +76,6 @@ Tk.tex: tk.mli
 
 clean:
 	rm -f $(FILES)
-
 
 .SUFFIXES:
 .SUFFIXES: .tex .etex .mli

--- a/manual/manual/library/check-stdlib-modules
+++ b/manual/manual/library/check-stdlib-modules
@@ -10,7 +10,7 @@ cut -c 2- $TMPDIR/stdlib-$$-files \
 exitcode=0
 for i in `cat $TMPDIR/stdlib-$$-modules`; do
   case $i in
-    Camlinternal* | *Labels | Obj | Pervasives) continue;;
+    Stdlib | Camlinternal* | *Labels | Obj | Pervasives) continue;;
   esac
   grep -q -e '"'$i'" & p\.~\\pageref{'$i'} &' stdlib.etex || {
     echo "Module $i is missing from stdlib.etex." >&2

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -187,16 +187,29 @@ STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
 PARSING_MLIS := $(wildcard ../parsing/*.mli)
 
 STDLIB_MLIS=\
-  $(STDLIB_MODULES:%=stdlib_non_prefixed/%.mli) \
-  $(PARSING_MLIS:../parsing/%.mli=stdlib_non_prefixed/%.mli) \
-  stdlib_non_prefixed/warnings.mli \
-  stdlib_non_prefixed/unix.mli \
-  stdlib_non_prefixed/str.mli \
-  stdlib_non_prefixed/bigarray.mli \
-  stdlib_non_prefixed/num.mli \
-  stdlib_non_prefixed/nat.mli \
-  stdlib_non_prefixed/big_int.mli \
-  stdlib_non_prefixed/ratio.mli
+  $(STDLIB_MODULES:%=%.mli) \
+  $(PARSING_MLIS:../parsing/%.mli=%.mli) \
+  warnings.mli \
+  unix.mli \
+  unixLabels.mli \
+  str.mli \
+  bigarray.mli \
+  num.mli \
+  arith_status.mli \
+  nat.mli \
+  big_int.mli \
+  ratio.mli \
+  graphics.mli \
+  graphicsX11.mli \
+  dynlink.mli \
+  thread.mli \
+  mutex.mli \
+  condition.mli \
+  event.mli \
+  threadUnix.mli
+
+STDLIB_MLIS:=$(addprefix stdlib_non_prefixed/, $(STDLIB_MLIS))
+
 
 STDLIB_CMIS=$(STDLIB_MLIS:%.mli=%.cmi)
 
@@ -445,6 +458,16 @@ stdlib_non_prefixed/%.mli: ../otherlibs/bigarray/%.mli
 
 stdlib_non_prefixed/%.mli: ../otherlibs/num/%.mli
 	cp $< $@
+
+stdlib_non_prefixed/%.mli: ../otherlibs/graph/%.mli
+	cp $< $@
+
+stdlib_non_prefixed/%.mli: ../otherlibs/threads/%.mli
+	cp $< $@
+
+stdlib_non_prefixed/%.mli: ../otherlibs/dynlink/%.mli
+	cp $< $@
+
 
 stdlib_non_prefixed/pervasives.mli: ../stdlib/stdlib.mli stdlib_non_prefixed/extract_pervasives.awk
 	$(AWK) -f stdlib_non_prefixed/extract_pervasives.awk $< > $@

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -180,38 +180,6 @@ LIBCMOFILES = $(CMOFILES)
 LIBCMXFILES = $(LIBCMOFILES:.cmo=.cmx)
 LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 
-P :=
-include ../stdlib/StdlibModules
-
-STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
-PARSING_MLIS := $(wildcard ../parsing/*.mli)
-
-STDLIB_MLIS=\
-  $(STDLIB_MODULES:%=%.mli) \
-  $(PARSING_MLIS:../parsing/%.mli=%.mli) \
-  warnings.mli \
-  unix.mli \
-  unixLabels.mli \
-  str.mli \
-  bigarray.mli \
-  num.mli \
-  arith_status.mli \
-  nat.mli \
-  big_int.mli \
-  ratio.mli \
-  graphics.mli \
-  graphicsX11.mli \
-  dynlink.mli \
-  thread.mli \
-  mutex.mli \
-  condition.mli \
-  event.mli \
-  threadUnix.mli
-
-STDLIB_MLIS:=$(addprefix stdlib_non_prefixed/, $(STDLIB_MLIS))
-
-
-STDLIB_CMIS=$(STDLIB_MLIS:%.mli=%.cmi)
 
 .PHONY: all
 all: lib exe generators manpages
@@ -409,6 +377,11 @@ test_texi:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -texi -sort -d $@ $(INCLUDES) odoc*.ml odoc*.mli
 
+# stdlib non-prefixed :
+#######################
+SRC=$(ROOTDIR)
+include Makefile.unprefix
+
 stdlib_man/Stdlib.3o: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
 	$(MKDIR) stdlib_man
 	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib -I stdlib_non_prefixed \
@@ -430,56 +403,6 @@ autotest_stdlib:
 	../otherlibs/$(UNIXLIB)/unix.mli \
 	../otherlibs/str/str.mli
 
-# stdlib non-prefixed :
-#######################
-
-OCAMLC_SNP = $(OCAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -nopervasives -I stdlib_non_prefixed
-
-stdlib_non_prefixed/%.mli: ../stdlib/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/camlinternalBigarray.mli: ../stdlib/camlinternalBigarray.ml
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../parsing/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../utils/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/$(UNIXLIB)/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/str/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/bigarray/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/num/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/graph/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/threads/%.mli
-	cp $< $@
-
-stdlib_non_prefixed/%.mli: ../otherlibs/dynlink/%.mli
-	cp $< $@
-
-
-stdlib_non_prefixed/pervasives.mli: ../stdlib/stdlib.mli stdlib_non_prefixed/extract_pervasives.awk
-	$(AWK) -f stdlib_non_prefixed/extract_pervasives.awk $< > $@
-
-stdlib_non_prefixed/pervasives.cmi: stdlib_non_prefixed/pervasives.mli
-	$(OCAMLC_SNP) -c $<
-
-stdlib_non_prefixed/camlinternalFormatBasics.cmi: stdlib_non_prefixed/camlinternalFormatBasics.mli
-	$(OCAMLC_SNP) -c $<
-
-stdlib_non_prefixed/%.cmi: stdlib_non_prefixed/%.mli stdlib_non_prefixed/pervasives.cmi
-	$(OCAMLC_SNP) -c -open Pervasives $<
 
 # odoc rules :
 ##############
@@ -542,6 +465,5 @@ depend:
 	$(OCAMLLEX) odoc_see_lexer.mll
 	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli > .depend
 	$(OCAMLDEP) $(INCLUDES_DEP) -shared generators/*.ml >> .depend
-	$(OCAMLDEP) -I stdlib_non_prefixed stdlib_non_prefixed/*.mli >> .depend
 
 include .depend

--- a/ocamldoc/Makefile.unprefix
+++ b/ocamldoc/Makefile.unprefix
@@ -1,0 +1,111 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                          Florian Angeletti                             *
+#*                                                                        *
+#*                            Copyright 2017                              *
+#*                                                                        *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+
+include $(SRC)/config/Makefile
+
+P :=
+VPATH=.:$(SRC)
+include $(SRC)/stdlib/StdlibModules
+
+STDLIB_UNPREFIXED=$(SRC)/ocamldoc/stdlib_non_prefixed
+
+STDLIB_MODULES := pervasives $(filter-out stdlib,$(STDLIB_MODULES))
+PARSING_MLIS := $(wildcard $(SRC)/parsing/*.mli)
+UTILS_MLIS := $(wildcard $(SRC)/utils/*.mli)
+TYPING_MLIS := $(wildcard $(SRC)/typing/*.mli)
+BYTECOMP_MLIS := $(wildcard $(SRC)/bytecomp/*.mli)
+
+# Documented modules: stdlib + otherlib + utils(?) + parsing(for compiler-libs)
+STDLIB_MLIS=\
+  $(STDLIB_MODULES:%=%.mli) \
+  $(PARSING_MLIS:$(SRC)/parsing/%.mli=%.mli) \
+  $(UTILS_MLIS:$(SRC)/utils/%.mli=%.mli) \
+  str.mli \
+  unix.mli unixLabels.mli \
+  bigarray.mli \
+  num.mli arith_status.mli big_int.mli ratio.mli \
+  graphics.mli graphicsX11.mli \
+  dynlink.mli \
+  thread.mli mutex.mli condition.mli event.mli threadUnix.mli \
+  pparse.mli
+
+STDLIB_MLIS:=$(addprefix $(STDLIB_UNPREFIXED)/, $(STDLIB_MLIS))
+
+# Dependencies for the documented modules
+STDLIB_DEPS:=$(STDLIB_MLIS) \
+  $(TYPING_MLIS:$(SRC)/typing/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
+  $(BYTECOMP_MLIS:$(SRC)/bytecomp/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
+  $(STDLIB_UNPREFIXED)/nat.mli
+
+# Add back the isolated modules in typing and bytecomp
+STDLIB_MLIS:= $(STDLIB_MLIS) \
+$(addprefix $(STDLIB_UNPREFIXED)/, typemod.mli simplif.mli)
+
+
+STDLIB_CMIS=$(STDLIB_DEPS:%.mli=%.cmi)
+
+
+# Copy mli files from the main source directory
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/stdlib/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/camlinternalBigarray.mli: $(SRC)/stdlib/camlinternalBigarray.ml
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/parsing/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/utils/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/$(UNIXLIB)/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/str/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/bigarray/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/num/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/graph/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/threads/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/otherlibs/dynlink/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/driver/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/typing/%.mli
+	cp $< $@
+
+$(STDLIB_UNPREFIXED)/%.mli: $(SRC)/bytecomp/%.mli
+	cp $< $@
+
+#Extract the pervasives module from stdlib.mli
+$(STDLIB_UNPREFIXED)/pervasives.mli: $(SRC)/stdlib/stdlib.mli $(STDLIB_UNPREFIXED)/extract_pervasives.awk
+	awk -f $(STDLIB_UNPREFIXED)/extract_pervasives.awk $< > $@
+
+# Build cmis file inside the STDLIB_UNPREFIXED directories
+$(STDLIB_CMIS): $(STDLIB_DEPS)
+	cd $(STDLIB_UNPREFIXED); make $(notdir $(STDLIB_CMIS))

--- a/ocamldoc/stdlib_non_prefixed/.depend
+++ b/ocamldoc/stdlib_non_prefixed/.depend
@@ -1,0 +1,185 @@
+annot.cmi : location.cmi
+arg.cmi :
+arg_helper.cmi : map.cmi
+arith_status.cmi :
+array.cmi :
+arrayLabels.cmi :
+ast_helper.cmi : parsetree.cmi longident.cmi location.cmi docstrings.cmi \
+    asttypes.cmi
+ast_invariants.cmi : parsetree.cmi
+ast_iterator.cmi : parsetree.cmi location.cmi
+ast_mapper.cmi : parsetree.cmi location.cmi
+asttypes.cmi : location.cmi
+attr_helper.cmi : parsetree.cmi location.cmi format.cmi asttypes.cmi
+big_int.cmi : nat.cmi
+bigarray.cmi : unix.cmi complex.cmi camlinternalBigarray.cmi
+btype.cmi : types.cmi set.cmi path.cmi map.cmi hashtbl.cmi format.cmi \
+    asttypes.cmi
+buffer.cmi : uchar.cmi
+builtin_attributes.cmi : parsetree.cmi location.cmi ast_iterator.cmi
+bytegen.cmi : lambda.cmi instruct.cmi
+bytelibrarian.cmi : format.cmi
+bytelink.cmi : symtable.cmi format.cmi digest.cmi cmo_format.cmi
+bytepackager.cmi : ident.cmi format.cmi env.cmi
+bytes.cmi :
+bytesLabels.cmi :
+bytesections.cmi :
+callback.cmi :
+camlinternalBigarray.cmi : complex.cmi
+camlinternalFormat.cmi : camlinternalFormatBasics.cmi buffer.cmi
+camlinternalFormatBasics.cmi :
+camlinternalLazy.cmi :
+camlinternalMod.cmi : obj.cmi
+camlinternalOO.cmi : obj.cmi
+ccomp.cmi :
+char.cmi :
+clflags.cmi : misc.cmi arg.cmi
+cmi_format.cmi : types.cmi format.cmi digest.cmi
+cmo_format.cmi : tbl.cmi lambda.cmi ident.cmi digest.cmi
+cmt_format.cmi : types.cmi typedtree.cmi location.cmi env.cmi digest.cmi \
+    cmi_format.cmi
+complex.cmi :
+condition.cmi : mutex.cmi
+config.cmi :
+consistbl.cmi : digest.cmi
+ctype.cmi : types.cmi path.cmi longident.cmi ident.cmi env.cmi asttypes.cmi
+datarepr.cmi : types.cmi path.cmi ident.cmi
+depend.cmi : set.cmi parsetree.cmi map.cmi longident.cmi
+digest.cmi :
+dll.cmi :
+docstrings.cmi : parsetree.cmi location.cmi lexing.cmi lazy.cmi
+dynlink.cmi : digest.cmi
+emitcode.cmi : instruct.cmi ident.cmi cmo_format.cmi
+env.cmi : warnings.cmi types.cmi subst.cmi path.cmi map.cmi longident.cmi \
+    location.cmi ident.cmi format.cmi digest.cmi consistbl.cmi cmi_format.cmi \
+    asttypes.cmi
+envaux.cmi : subst.cmi path.cmi format.cmi env.cmi
+ephemeron.cmi : hashtbl.cmi
+event.cmi :
+filename.cmi :
+format.cmi : pervasives.cmi buffer.cmi
+gc.cmi :
+genlex.cmi : stream.cmi
+graphics.cmi :
+graphicsX11.cmi :
+hashtbl.cmi :
+ident.cmi : identifiable.cmi
+identifiable.cmi : set.cmi map.cmi hashtbl.cmi format.cmi
+includeclass.cmi : types.cmi location.cmi format.cmi env.cmi ctype.cmi
+includecore.cmi : types.cmi typedtree.cmi location.cmi ident.cmi format.cmi \
+    env.cmi
+includemod.cmi : types.cmi typedtree.cmi path.cmi location.cmi \
+    includecore.cmi ident.cmi format.cmi env.cmi ctype.cmi
+instruct.cmi : types.cmi subst.cmi location.cmi lambda.cmi ident.cmi env.cmi
+int32.cmi :
+int64.cmi :
+lambda.cmi : types.cmi set.cmi primitive.cmi path.cmi location.cmi ident.cmi \
+    env.cmi asttypes.cmi
+lazy.cmi :
+lexer.cmi : parser.cmi location.cmi lexing.cmi format.cmi
+lexing.cmi :
+list.cmi :
+listLabels.cmi :
+location.cmi : warnings.cmi lexing.cmi format.cmi
+longident.cmi :
+map.cmi :
+marshal.cmi :
+matching.cmi : typedtree.cmi location.cmi lambda.cmi ident.cmi
+meta.cmi : obj.cmi instruct.cmi
+misc.cmi : set.cmi map.cmi hashtbl.cmi format.cmi
+moreLabels.cmi : set.cmi map.cmi hashtbl.cmi
+mtype.cmi : types.cmi path.cmi ident.cmi env.cmi
+mutex.cmi :
+nat.cmi :
+nativeint.cmi :
+num.cmi : ratio.cmi nat.cmi big_int.cmi
+numbers.cmi : set.cmi int64.cmi identifiable.cmi
+obj.cmi : int32.cmi
+oo.cmi : camlinternalOO.cmi
+oprint.cmi : outcometree.cmi format.cmi
+outcometree.cmi : format.cmi asttypes.cmi
+parmatch.cmi : types.cmi typedtree.cmi parsetree.cmi longident.cmi \
+    location.cmi hashtbl.cmi format.cmi env.cmi asttypes.cmi
+parse.cmi : parsetree.cmi lexing.cmi
+parser.cmi : parsetree.cmi location.cmi lexing.cmi docstrings.cmi
+parsetree.cmi : longident.cmi location.cmi asttypes.cmi
+parsing.cmi : obj.cmi lexing.cmi
+path.cmi : ident.cmi
+pervasives.cmi : camlinternalFormatBasics.cmi
+pparse.cmi : parsetree.cmi misc.cmi lexing.cmi format.cmi
+pprintast.cmi : parsetree.cmi format.cmi
+predef.cmi : types.cmi path.cmi ident.cmi
+primitive.cmi : parsetree.cmi outcometree.cmi location.cmi
+printast.cmi : parsetree.cmi format.cmi
+printexc.cmi :
+printf.cmi : buffer.cmi
+printinstr.cmi : instruct.cmi format.cmi
+printlambda.cmi : lambda.cmi format.cmi
+printtyp.cmi : types.cmi path.cmi outcometree.cmi longident.cmi ident.cmi \
+    format.cmi env.cmi asttypes.cmi
+printtyped.cmi : typedtree.cmi format.cmi
+queue.cmi :
+random.cmi : nativeint.cmi int64.cmi int32.cmi
+ratio.cmi : nat.cmi big_int.cmi
+runtimedef.cmi :
+scanf.cmi : pervasives.cmi
+semantics_of_primitives.cmi : lambda.cmi
+set.cmi :
+simplif.cmi : misc.cmi location.cmi lambda.cmi ident.cmi
+sort.cmi :
+spacetime.cmi :
+stack.cmi :
+stdLabels.cmi : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
+    arrayLabels.cmi
+str.cmi :
+stream.cmi :
+string.cmi :
+stringLabels.cmi :
+strongly_connected_components.cmi : identifiable.cmi
+stypes.cmi : typedtree.cmi location.cmi annot.cmi
+subst.cmi : types.cmi path.cmi ident.cmi
+switch.cmi : location.cmi
+symtable.cmi : obj.cmi misc.cmi lambda.cmi ident.cmi format.cmi digest.cmi \
+    cmo_format.cmi
+syntaxerr.cmi : location.cmi format.cmi
+sys.cmi :
+targetint.cmi :
+tast_mapper.cmi : typedtree.cmi env.cmi asttypes.cmi
+tbl.cmi : format.cmi
+terminfo.cmi :
+thread.cmi : unix.cmi
+threadUnix.cmi : unix.cmi
+timings.cmi : format.cmi
+translattribute.cmi : typedtree.cmi parsetree.cmi location.cmi lambda.cmi
+translclass.cmi : typedtree.cmi location.cmi lambda.cmi ident.cmi format.cmi \
+    asttypes.cmi
+translcore.cmi : types.cmi typedtree.cmi primitive.cmi path.cmi location.cmi \
+    lambda.cmi ident.cmi hashtbl.cmi format.cmi env.cmi asttypes.cmi
+translmod.cmi : typedtree.cmi primitive.cmi location.cmi lambda.cmi \
+    ident.cmi format.cmi
+translobj.cmi : lambda.cmi ident.cmi env.cmi
+typeclass.cmi : types.cmi typedtree.cmi parsetree.cmi longident.cmi \
+    location.cmi ident.cmi format.cmi env.cmi ctype.cmi asttypes.cmi
+typecore.cmi : types.cmi typedtree.cmi path.cmi parsetree.cmi longident.cmi \
+    location.cmi ident.cmi format.cmi env.cmi asttypes.cmi annot.cmi
+typedecl.cmi : types.cmi typedtree.cmi path.cmi parsetree.cmi longident.cmi \
+    location.cmi includecore.cmi ident.cmi format.cmi env.cmi asttypes.cmi
+typedtree.cmi : types.cmi primitive.cmi path.cmi parsetree.cmi longident.cmi \
+    location.cmi ident.cmi env.cmi asttypes.cmi
+typedtreeIter.cmi : typedtree.cmi asttypes.cmi
+typedtreeMap.cmi : typedtree.cmi
+typemod.cmi : types.cmi typedtree.cmi path.cmi parsetree.cmi misc.cmi \
+    longident.cmi location.cmi includemod.cmi ident.cmi format.cmi env.cmi \
+    cmi_format.cmi asttypes.cmi
+typeopt.cmi : types.cmi typedtree.cmi path.cmi lambda.cmi env.cmi
+types.cmi : set.cmi primitive.cmi path.cmi parsetree.cmi map.cmi \
+    longident.cmi location.cmi ident.cmi asttypes.cmi
+typetexp.cmi : types.cmi typedtree.cmi path.cmi parsetree.cmi longident.cmi \
+    location.cmi format.cmi env.cmi asttypes.cmi
+uchar.cmi :
+unix.cmi : camlinternalBigarray.cmi
+unixLabels.cmi : unix.cmi
+untypeast.cmi : typedtree.cmi path.cmi parsetree.cmi longident.cmi \
+    location.cmi asttypes.cmi
+warnings.cmi : lexing.cmi
+weak.cmi : hashtbl.cmi

--- a/ocamldoc/stdlib_non_prefixed/Makefile
+++ b/ocamldoc/stdlib_non_prefixed/Makefile
@@ -1,0 +1,25 @@
+TOPDIR=$(abspath ../..)
+include $(TOPDIR)/Makefile.tools
+
+.SUFFIXES:
+
+OCAMLDEP= $(OCAMLRUN) $(TOPDIR)/tools/ocamldep -slash
+OCAMLC_SNP= $(OCAMLRUN) $(TOPDIR)/ocamlc -nostdlib -nopervasives -I $(HERE)
+
+pervasives.cmi: pervasives.mli camlinternalFormatBasics.cmi
+	$(OCAMLC_SNP) -c $<
+
+camlinternalFormatBasics.cmi: \
+camlinternalFormatBasics.mli
+	$(OCAMLC_SNP) -c $<
+
+%.cmi: %.mli pervasives.cmi
+	$(OCAMLC_SNP) -c -open Pervasives $<
+
+depend:
+	$(OCAMLDEP) *.mli > .depend
+
+include .depend
+
+clean:
+	rm *.mli *.cmi


### PR DESCRIPTION
This PR fixes the build process by factoring the build process of the unprefixed stdlib between ocamldoc and the manual though a `ocamldoc/Makefile.unprefixed` and `ocamldoc/stdlib_non_prefixed/Makefile` makefiles. (I am not too sure about the emplacement but using the ocamldoc directory for an ocamldoc workaroud sounded fine).

Note that the first commit of the PR implements a more limited fix, but I feared that it would make too easy to end up with stale stdlib documentation in the manual. The second commit is more involved but should ensure that the mli files used when building the manual are up-to-date.

Please feel free to cherry-pick or discard any part of this PR.